### PR TITLE
added prettier config in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,17 @@
   "repository": "git@github.com:AlexZeitler/vscode-prettier-eslint-typescript.git",
   "author": "Alexander Zeitler <alexander.zeitler@pdmlab.com>",
   "license": "MIT",
+  "prettier": {
+    "printWidth": 80,
+    "tabWidth": 2,
+    "singleQuote": true,
+    "trailingComma": "none",
+    "bracketSpacing": true,
+    "semi": false,
+    "useTabs": false,
+    "jsxBracketSameLine": false,
+    "proseWrap": "never"
+  },
   "devDependencies": {
     "@types/mocha": "^5.2.6",
     "@types/node": "^10.12.18",

--- a/src/GetEnvTyped.ts
+++ b/src/GetEnvTyped.ts
@@ -1,9 +1,12 @@
-type SimpleType = string | number | boolean;
+type SimpleType = string | number | boolean
 
 interface SimpleConstructor<T extends SimpleType> {
-  (value: any): T;
+  (value: any): T
 }
 
-export function getEnv<T extends SimpleType>(name: string, cast: SimpleConstructor<T>): T { 
-  return cast(process.env[name]);
+export function getEnv<T extends SimpleType>(
+  name: string,
+  cast: SimpleConstructor<T>
+): T {
+  return cast(process.env[name])
 }

--- a/test/GetEnvTypedTests.ts
+++ b/test/GetEnvTypedTests.ts
@@ -6,7 +6,7 @@ import { getEnv } from '../src/GetEnvTyped'
 describe('getEnv', (): void => {
   describe('when requesting a string value from environment', (): void => {
     it('should return a string value', (done): void => {
-      process.env.FOO = 'foo';
+      process.env.FOO = 'foo'
       const foo = getEnv('FOO', String)
       foo.should.equal('foo')
       return done()


### PR DESCRIPTION
the prettier eslint extension in vscode has several problems, e. g. latest lint version.

It seems that it is currently so buggy that I would not recommend it and wait till all eslint 6x changes got through all plugins + extensions.

In generell I currently tend to just add prettier config and remove all formatting rules from eslint